### PR TITLE
Pin version of python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.1.2',
     description='Compare string distances between dates, timestamps, or datetime objects.',
     packages=['datetime_distance'],
-    install_requires=['python-dateutil',
+    install_requires=['python-dateutil>=2.6.0',
                       'future'],
     license='The MIT License: http://www.opensource.org/licenses/mit-license.php',
     classifiers=[


### PR DESCRIPTION
An older version of dateutil on the Dedupe production server has different behavior for the `parse` method. This PR pins the package version to >=2.6.0 to avoid that.