### PR TITLE
Use an OrderedDict to keep track of the names of date resolutions

### DIFF
--- a/datetime_distance/__init__.py
+++ b/datetime_distance/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 import math
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 from dateutil.parser import parse
 import dateutil.parser as parser
@@ -26,11 +26,13 @@ class DateTimeComparator(object):
         self.yearfirst = yearfirst  # Ambiguous dates are parsed yy/mm/dd
         # Default is month-first
 
-        # Map output indeces to make code more readiable
-        self.res_map = {'seconds': 0,
-                        'days':    1,
-                        'months':  2,
-                        'years':   3}
+        # Map output indeces to make code more readable
+        resolutions = {'seconds': 0,
+                       'days':    1,
+                       'months':  2,
+                       'years':   3}
+        self.res_map = OrderedDict(sorted(resolutions.items(),
+                                          key=lambda x: x[1]))
 
         # Make the resolution parser a class method
         self.parse_resolution = parser.parser().resolution


### PR DESCRIPTION
In order to prepare the distance vector for DateTime comparisons, we use a simple map to help us move between detected resolutions and the indeces of the corresponding variables in the vector [(source)](https://github.com/dedupeio/datetime-distance/blob/master/datetime_distance/__init__.py#L30-L33):

```python
        self.res_map = {'seconds': 0,
                        'days':    1,
                        'months':  2,
                        'years': 3}
```

We use this map to build the vector in `_format_output` [(source)](https://github.com/dedupeio/datetime-distance/blob/master/datetime_distance/__init__.py#L148-L155):

```python
    def _format_output(self, diff, resolution):

        # Format output template with the right resolution and delta
        output = [0 for _ in range(8)]
        output[self.res_map[resolution]] = 1
        output[4 + self.res_map[resolution]] = diff

        return self._make_tuple(output)
```

The last call in this block, `_make_tuple`, assumes that there is an inherent order to the resolution map, however:

```python
    def _make_tuple(self, tup):

        # Return a named tuple
        tup_names = [res + '_dummy' for res in self.res_map.keys()]
        tup_names += [res + '_derived' for res in self.res_map.keys()]
        Output = namedtuple('DateTime', tup_names)

        return Output._make(tup)
```
Since dictionaries have no inherent order, the names attached to each position in the output vector were not what we expected. (I don't know enough about the way Dedupe handles distance vectors to be able to judge how serious of a bug this was, but it seems like something we should fix.)

To validate the working assumptions of the code, this PR makes a small change to store `res_map` as an OrderedDict, so that both `_format_output` and `_make_tuple` can work properly. 